### PR TITLE
chore(): add cleanup of ongoing messages before shutdown

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/opptjening/hendelse/api/HendelseService.kt
+++ b/src/main/kotlin/no/nav/pensjon/opptjening/hendelse/api/HendelseService.kt
@@ -37,7 +37,7 @@ class HendelseService(
                 PublishEventResult.Ok(offsets)
             }
         } catch (ex: Exception) {
-            log.error("Feil ved transaksjonell publisering av hendelser: $hendelser til kafka: $ex")
+            log.error("Feil ved transaksjonell publisering av hendelser: $hendelser til kafka med exception: $ex")
             PublishEventResult.EventError()
         }
     }

--- a/src/main/kotlin/no/nav/pensjon/opptjening/hendelse/kafka/CustomProducerListener.kt
+++ b/src/main/kotlin/no/nav/pensjon/opptjening/hendelse/kafka/CustomProducerListener.kt
@@ -40,8 +40,8 @@ class CustomProducerListener : ProducerListener<String, String> {
                     "Partition: ${producerRecord?.partition() ?: "unknown"}, " +
                     "Offset: ${recordMetadata?.offset() ?: "unknown"}, " +
                     "Timestamp: ${LocalDateTime.now()}, " +
-                    "Key: ${producerRecord?.key() ?: "unknown/null"}" +
-                    "Payload: ${producerRecord?.value() ?: "unknown"}" +
+                    "Key: ${producerRecord?.key() ?: "unknown/null"}, " +
+                    "Payload: ${producerRecord?.value() ?: "unknown"}, " +
                     "Exception: ${exception?.message ?: "unknown"}"
         )
     }


### PR DESCRIPTION
* i see many error messages in log during deploy. Try to do a cleanup of ongoing messages before shutdown