### PR TITLE
#nf - chore: update Gradle actions to v6 and switch docker to java 25

### DIFF
--- a/.github/workflows/build_deploy_test.yml
+++ b/.github/workflows/build_deploy_test.yml
@@ -28,6 +28,11 @@ jobs:
 
       - name: 'Generate and submit dependency graph'
         uses: gradle/actions/dependency-submission@v6
+        with:
+          # setup-gradle already manages the Gradle User Home cache. dependency-submission
+          # enables its own caching by default, so disable it here to avoid duplicate
+          # cache restore/save work and extra runtime overhead.
+          cache-disabled: true
 
       - name: 'Setter dato og commit variabel'
         run: |

--- a/.github/workflows/build_deploy_test.yml
+++ b/.github/workflows/build_deploy_test.yml
@@ -24,10 +24,10 @@ jobs:
           cache: 'gradle'
 
       - name: 'Setup Gradle'
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6
 
       - name: 'Generate and submit dependency graph'
-        uses: gradle/actions/dependency-submission@v5
+        uses: gradle/actions/dependency-submission@v6
 
       - name: 'Setter dato og commit variabel'
         run: |
@@ -39,12 +39,6 @@ jobs:
       - name: 'Configure git reference tag'
         run: |
           echo "GIT_REF_TAG=git_${GIT_BRANCH}_${GIT_COMMIT}" >> $GITHUB_ENV
-
-      - name: 'Setup Gradle'
-        uses: gradle/actions/setup-gradle@v5
-
-      - name: 'Generate and submit dependency graph'
-        uses: gradle/actions/dependency-submission@v5
 
       - name: 'Build artifact'
         run: |

--- a/.github/workflows/gradle-dependency-submission.yml
+++ b/.github/workflows/gradle-dependency-submission.yml
@@ -19,7 +19,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 25
-          cache: gradle
 
       - name: 'Generate and submit dependency graph'
         uses: gradle/actions/dependency-submission@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jre
+FROM eclipse-temurin:25-jre
 
 RUN apt-get update && apt-get install -y \
   curl \


### PR DESCRIPTION
# bump docker to java 25
this was missing on last PR

# Removed redundant Gradle setup steps
I removed the Setup Gradle and Generate and submit dependency graph steps because the dependency-submission action already configures Gradle internally as part of its execution. That action:
* Sets up the Gradle environment automatically.
* Provides Gradle-aware caching of dependencies and build state.
* Runs the build needed to resolve and submit the dependency graph.
Since all of this is handled by dependency-submission, a separate setup-gradle step only duplicated the setup and caching, adding overhead without benefit. Removing it leaves a cleaner workflow with no loss of functionality.
